### PR TITLE
Seperate AssemblyInfo From Solution

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
+++ b/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Exceptions\ContextPropertyNotFoundException.cs" />
     <Compile Include="Guards\Guard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
@@ -1,36 +1,11 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Core")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BizTalk.Extended.Core")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("06711e89-9bc2-486f-866e-2659b820fcdf")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.csproj
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.csproj
@@ -48,6 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\XLANGMessageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
@@ -5,32 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Orchestrations.Extensions")]
-[assembly: AssemblyDescription("Extensions that take BizTalk orchestration development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
 [assembly: AssemblyProduct("BizTalk.Extended.Orchestrations.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8abacda6-3ed0-41d2-ac5b-3024b8fc015f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/Extensions/BaseMessageExtensionsTests.cs
+++ b/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/Extensions/BaseMessageExtensionsTests.cs
@@ -13,6 +13,11 @@ namespace BizTalk.Extended.Pipeline.Core.UnitTests.Extensions
         private const string ActionPropertyName = "Action";
         private const string ActionPropertyNamespace = "http://schemas.microsoft.com/BizTalk/2006/01/Adapters/WCF-properties";
 
+        // TODO: Tests where a value type is null and not marked as nullable
+        // TODO: Tests where a value type is null and marked as nullable
+        // TODO: Tests where an enum value is null and not marked as nullable
+        // TODO: Tests where an enum value is null and marked as nullable
+
         [Fact]
         public void PromoteContextProperty_MessageIsNull_ThrowsArgumentNullException()
         {

--- a/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.csproj
+++ b/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.csproj
@@ -51,6 +51,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\BaseMessageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
@@ -1,37 +1,11 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
 [assembly: AssemblyProduct("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("adc2f501-f327-48e2-83d9-07b91721280f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.csproj
+++ b/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.csproj
@@ -49,6 +49,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="PipelineComponent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
@@ -1,36 +1,11 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.General")]
-[assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
-[assembly: AssemblyProduct("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+[assembly: AssemblyProduct("BizTalk.Extended.Pipelines.General")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("98b67945-dafc-403c-a4a4-69861ce00984")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Extract generic AssemblyInfo file and re-use in existing projects.

Relates to #11