### PR TITLE
Seperate assembly info

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
+[assembly: AssemblyProduct("BizTalk.Extended.Orchestrations.Extensions")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Core.UnitTests/BizTalk.Extended.Core.UnitTests.csproj
+++ b/src/BizTalk.Extended.Core.UnitTests/BizTalk.Extended.Core.UnitTests.csproj
@@ -53,6 +53,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Guard\GuardTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Core.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Core.UnitTests/Properties/AssemblyInfo.cs
@@ -7,30 +7,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Core.UnitTests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BizTalk.Extended.Core.UnitTests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b380017d-e4b3-455a-a568-2f78ae632981")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
+++ b/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Exceptions\ContextPropertyNotFoundException.cs" />
     <Compile Include="Guards\Guard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,30 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Core")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BizTalk.Extended.Core")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("06711e89-9bc2-486f-866e-2659b820fcdf")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Core/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Core")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Core libraries for BizTalk<Extended> that takes BizTalk development to the next level.")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("06711e89-9bc2-486f-866e-2659b820fcdf")]

--- a/src/BizTalk.Extended.Orchestrations.Extensions.UnitTests/BizTalk.Extended.Orchestrations.Extensions.UnitTests.csproj
+++ b/src/BizTalk.Extended.Orchestrations.Extensions.UnitTests/BizTalk.Extended.Orchestrations.Extensions.UnitTests.csproj
@@ -65,6 +65,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\XLANGMessageExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Orchestrations.Extensions.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Orchestrations.Extensions.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,30 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Orchestrations.Extensions.UnitTests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BizTalk.Extended.Orchestrations.Extensions.UnitTests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e85114f0-faa4-43bb-a15c-001366cfaf52")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.csproj
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.csproj
@@ -48,6 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\XLANGMessageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Orchestrations.Extensions")]
-[assembly: AssemblyDescription("Extensions that take BizTalk orchestration development to the next level.")]
+[assembly: AssemblyDescription("Orchestration extensions that take BizTalk development to the next level.")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8abacda6-3ed0-41d2-ac5b-3024b8fc015f")]

--- a/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/Properties/AssemblyInfo.cs
@@ -6,31 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Orchestrations.Extensions")]
 [assembly: AssemblyDescription("Extensions that take BizTalk orchestration development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
-[assembly: AssemblyProduct("BizTalk.Extended.Orchestrations.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8abacda6-3ed0-41d2-ac5b-3024b8fc015f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/BizTalk.Extended.Pipelines.Extensions.UnitTests.csproj
+++ b/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/BizTalk.Extended.Pipelines.Extensions.UnitTests.csproj
@@ -57,6 +57,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\BaseMessageExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.Extensions.UnitTests/Properties/AssemblyInfo.cs
@@ -7,30 +7,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.Extensions.UnitTests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BizTalk.Extended.Pipelines.Extensions.UnitTests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3b3ac3fe-5f39-4b21-8b1f-cb009819f410")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.csproj
+++ b/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.csproj
@@ -51,6 +51,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Extensions\BaseMessageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,31 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.Extensions")]
 [assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
-[assembly: AssemblyProduct("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("adc2f501-f327-48e2-83d9-07b91721280f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.Extensions/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
+[assembly: AssemblyDescription("Pipeline Component extensions that takes BizTalk development to the next level.")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("adc2f501-f327-48e2-83d9-07b91721280f")]

--- a/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.csproj
+++ b/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.csproj
@@ -49,6 +49,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="PipelineComponent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,30 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.General")]
 [assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Sam Neirinck, Tom Kerkhove, Glenn Colpaert, Jonathan Maes")]
-[assembly: AssemblyProduct("BizTalk.Extended.Pipelines.Extensions")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("98b67945-dafc-403c-a4a4-69861ce00984")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Pipelines.General/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BizTalk.Extended.Pipelines.General")]
-[assembly: AssemblyDescription("Extensions that take BizTalk pipeline development to the next level.")]
+[assembly: AssemblyDescription("Generic Pipeline Component extensibility that takes BizTalk development to the next level.")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("98b67945-dafc-403c-a4a4-69861ce00984")]


### PR DESCRIPTION
Use one generic AssemblyInfo file for all libraries.

Relates to #11.