### PR TITLE
Prepare for initial release (v0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ BizTalk<Extended\> offers the following features:
 
 - Typed interaction with the message context
 
+# Installation
+If you want to include BizTalk<Extended> in your project, you can install it directly from NuGet.
+
+To install BizTalk<Extended>, run the following command in the Package Manager Console:
+
+	PM> Install-Package BizTalk.Extended.Pipelines.General	
+	PM> Install-Package BizTalk.Extended.Pipelines.Extensions
+	PM> Install-Package BizTalk.Extended.Orchestrations.Extensions
+
 # Documentation
 ## Typed interaction with message context
 Fixed strings in code are evil and should be avoided at all times when possible to prevent typos or breaking changes when a namespace changes, especially when interacting with the message context.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ BizTalk<Extended\> offers the following features:
 - Typed interaction with the message context
 
 # Installation
-If you want to include BizTalk<Extended> in your project, you can install it directly from NuGet.
+If you want to include BizTalk<Extended\> in your project, you can install it directly from NuGet.
 
-To install BizTalk<Extended>, run the following command in the Package Manager Console:
+To install BizTalk<Extended\>, run the following command in the Package Manager Console:
 
 	PM> Install-Package BizTalk.Extended.Pipelines.General	
 	PM> Install-Package BizTalk.Extended.Pipelines.Extensions

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]
 [assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.nuspec
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/BizTalk.Extended.Orchestrations.Extensions.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>BizTalk.Extended.Orchestration.Extensions</id>
     <version>$version$</version>
-    <title>BizTalk&lt;Extended&gt; Orchestration Extensions</title>
+    <title>BizTalk&lt;Extended&gt; - Orchestration Extensions</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
     <projectUrl>https://github.com/CoditEU/Mjolnir</projectUrl>

--- a/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.nuspec
+++ b/src/BizTalk.Extended.Pipelines.Extensions/BizTalk.Extended.Pipelines.Extensions.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>BizTalk.Extended.Pipelines.Extensions</id>
     <version>$version$</version>
-    <title>BizTalk&lt;Extended&gt; Pipeline Extensions</title>
+    <title>BizTalk&lt;Extended&gt; - Pipeline Extensions</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
     <projectUrl>https://github.com/CoditEU/Mjolnir</projectUrl>

--- a/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.nuspec
+++ b/src/BizTalk.Extended.Pipelines.General/BizTalk.Extended.Pipelines.General.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>BizTalk.Extended.Pipelines.Extensions</id>
+    <id>BizTalk.Extended.Pipelines.General</id>
     <version>$version$</version>
-    <title>BizTalk&lt;Extended&gt; Pipeline Extensions</title>
+    <title>BizTalk&lt;Extended&gt; - Pipelines</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
     <projectUrl>https://github.com/CoditEU/Mjolnir</projectUrl>
@@ -11,5 +11,8 @@
     <description>$description$</description>
     <copyright>Copyright 2015</copyright>
     <tags>BizTalk Pipeline Mjolnir Codit</tags>
+    <dependencies>
+        <dependency id="BizTalk.Extended.Pipelines.Extensions" />
+    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Prepare for initial release (v0.1.0):
- Updated `README.md` with "Installation"
- Changed `AssemblyFileInfo` to `v0.1.0`
- Adapted `*.nuspec` to with prettier title & dependency in package `*.Pipelines.General` on `*.Pipelines.Extensions`