### PR TITLE
Remove XLANG dependency

### DIFF
--- a/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
+++ b/src/BizTalk.Extended.Core/BizTalk.Extended.Core.csproj
@@ -58,7 +58,6 @@
     <Compile Include="Exceptions\ContextPropertyNotFoundException.cs" />
     <Compile Include="Guards\Guard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utilities\ContextPropertyValueConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\BizTalk.Extended.snk">

--- a/src/BizTalk.Extended.Orchestrations.Core/BizTalk.Extended.Orchestrations.Core.csproj
+++ b/src/BizTalk.Extended.Orchestrations.Core/BizTalk.Extended.Orchestrations.Core.csproj
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8894C16D-0F6C-4BA8-9E07-95C4CA7C53EC}</ProjectGuid>
+    <ProjectGuid>{D30C8F4B-289D-4D63-9BF8-47A83E60D153}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BizTalk.Extended.Orchestrations.Extensions</RootNamespace>
-    <AssemblyName>BizTalk.Extended.Orchestrations.Extensions</AssemblyName>
+    <RootNamespace>BizTalk.Extended.Orchestrations.Core</RootNamespace>
+    <AssemblyName>BizTalk.Extended.Orchestrations.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,39 +37,33 @@
     <AssemblyOriginatorKeyFile>..\BizTalk.Extended.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.XLANGs.BaseTypes">
-      <HintPath>..\..\lib\Microsoft.XLANGs.BaseTypes.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.XLANGs.BaseTypes, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.cs">
       <Link>AssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Extensions\XLANGMessageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\BizTalk.Extended.snk">
-      <Link>BizTalk.Extended.snk</Link>
-    </None>
-    <None Include="BizTalk.Extended.Orchestrations.Extensions.nuspec" />
+    <Compile Include="Utilities\ContextPropertyValueConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BizTalk.Extended.Core\BizTalk.Extended.Core.csproj">
       <Project>{dfe2eb21-14f3-4138-a4a9-83e4a6c44932}</Project>
       <Name>BizTalk.Extended.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\BizTalk.Extended.Orchestrations.Core\BizTalk.Extended.Orchestrations.Core.csproj">
-      <Project>{d30c8f4b-289d-4d63-9bf8-47a83e60d153}</Project>
-      <Name>BizTalk.Extended.Orchestrations.Core</Name>
-    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\BizTalk.Extended.snk">
+      <Link>BizTalk.Extended.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/BizTalk.Extended.Orchestrations.Core/Properties/AssemblyInfo.cs
+++ b/src/BizTalk.Extended.Orchestrations.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BizTalk.Extended.Orchestrations.Core")]
+[assembly: AssemblyDescription("Core libraries specific to BizTalk orchestrations")]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d30c8f4b-289d-4d63-9bf8-47a83e60d153")]

--- a/src/BizTalk.Extended.Orchestrations.Core/Utilities/ContextPropertyValueConverter.cs
+++ b/src/BizTalk.Extended.Orchestrations.Core/Utilities/ContextPropertyValueConverter.cs
@@ -1,8 +1,7 @@
-﻿using BizTalk.Extended.Core.Guards;
-using Microsoft.XLANGs.BaseTypes;
+﻿using Microsoft.XLANGs.BaseTypes;
 using System;
 
-namespace BizTalk.Extended.Core.Utilities
+namespace BizTalk.Extended.Orchestrations.Core.Utilities
 {
     public class ContextPropertySerializer
     {

--- a/src/BizTalk.Extended.Orchestrations.Extensions/Extensions/XLANGMessageExtensions.cs
+++ b/src/BizTalk.Extended.Orchestrations.Extensions/Extensions/XLANGMessageExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using BizTalk.Extended.Core.Exceptions;
 using BizTalk.Extended.Core.Guards;
-using BizTalk.Extended.Core.Utilities;
+using BizTalk.Extended.Orchestrations.Core.Utilities;
 
 namespace Microsoft.XLANGs.BaseTypes
 {

--- a/src/BizTalk.Extended.sln
+++ b/src/BizTalk.Extended.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BizTalk.Extended.Pipelines.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BizTalk.Extended.Orchestrations.Extensions.UnitTests", "BizTalk.Extended.Orchestrations.Extensions.UnitTests\BizTalk.Extended.Orchestrations.Extensions.UnitTests.csproj", "{E85114F0-FAA4-43BB-A15C-001366CFAF52}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BizTalk.Extended.Orchestrations.Core", "BizTalk.Extended.Orchestrations.Core\BizTalk.Extended.Orchestrations.Core.csproj", "{D30C8F4B-289D-4D63-9BF8-47A83E60D153}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{E85114F0-FAA4-43BB-A15C-001366CFAF52}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E85114F0-FAA4-43BB-A15C-001366CFAF52}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E85114F0-FAA4-43BB-A15C-001366CFAF52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D30C8F4B-289D-4D63-9BF8-47A83E60D153}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D30C8F4B-289D-4D63-9BF8-47A83E60D153}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D30C8F4B-289D-4D63-9BF8-47A83E60D153}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D30C8F4B-289D-4D63-9BF8-47A83E60D153}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Remove the XLANG dependency from the Core-library to avoid referencing
the XLANG dlls when only using the IBaseMessage APIs.

Relates to #33. 